### PR TITLE
Base64 decode that permits padding

### DIFF
--- a/internal/provider/gcp/utils.go
+++ b/internal/provider/gcp/utils.go
@@ -12,7 +12,7 @@ import (
 
 // Discover discovers all GCR assets
 func Discover(serviceAccount string, emitFn func(result shared.CloudDiscoveryResult)) {
-	sa, err := base64.RawStdEncoding.DecodeString(serviceAccount)
+	sa, err := base64.StdEncoding.DecodeString(serviceAccount)
 	if err != nil {
 		log.Errorf(err.Error())
 		return


### PR DESCRIPTION
Previously we expected RawStdEncoding with no padding chars `=`. But depending on file length of a user's credential json, with standard base64 encoding commands there may be padding chars at the end of the base64 string to bring the length mod 3 == 0.

This commit allows padding characters by using StdEncoding instead.