### PR TITLE
Add open source licenses to image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
 cert*
+licenses

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app cmd/server/ma
 
 FROM alpine:3.8
 RUN apk --no-cache add ca-certificates nmap
+WORKDIR /licenses
+COPY /licenses/* ./
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/twistlock/cloud-discovery/app .
 CMD ["./app"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 .PHONY: build
 
 build:
+	# Find all of the open source LICENSE files in the source code and include them in a /licenses directory inside the container image.
+	# Inclusion of the license files may be a requirement for some to distribute the cloud-discovery container image.
+	rm -rf licenses; mkdir -p licenses; find . | grep LICENSE | while IFS= read -r pathname; do filename=$$(echo $$pathname | tr "\.\/" "_" | sed "s/^__//"); cp $$pathname licenses/$$filename; done
 	docker build -t twistlock/cloud-discovery .


### PR DESCRIPTION
This commit adds a script step to the Makefile to copy the open source LICENSE files from source directories into a /licenses directory and copy those licenses into the image for OSS compliance reasons.